### PR TITLE
Prevent negative/oversize queue size

### DIFF
--- a/methods.py
+++ b/methods.py
@@ -552,12 +552,13 @@ class Queue(multiprocessing.queues.Queue):
         self.size = SharedCounter(0)
 
     def put(self, *args, **kwargs):
-        self.size.increment(1)
         super(Queue, self).put(*args, **kwargs)
+        self.size.increment(1)
 
     def get(self, *args, **kwargs):
+        item = super(Queue, self).get(*args, **kwargs)
         self.size.increment(-1)
-        return super(Queue, self).get(*args, **kwargs)
+        return item
 
     def qsize(self):
         """ Reliable implementation of multiprocessing.Queue.qsize() """

--- a/test/test_methods.py
+++ b/test/test_methods.py
@@ -24,7 +24,10 @@ import StringIO
 import operator
 import os
 import random
+import time
 import warnings
+
+from Queue import Full, Empty
 
 # LEMON modules
 from test import unittest
@@ -368,3 +371,31 @@ class StreamToWarningFilterTest(unittest.TestCase):
         # Must close the underlying file object
         devnull_filter.close()
         self.assertTrue(fd.closed)
+
+
+class MethodsQueueTest(unittest.TestCase):
+
+    def test_queue_min_size(self):
+        q = methods.Queue(1)
+        self.assertEqual(q.qsize(), 0)
+        try:
+            q.get_nowait()
+        except Empty:
+            pass
+        self.assertEqual(q.qsize(), 0)
+
+    def test_queue_max_size(self):
+        q = methods.Queue(1)
+
+        self.assertEqual(0, q.qsize())
+        q.put_nowait("1")
+        self.assertEqual(1, q.qsize())
+        try:
+            q.put_nowait("1")
+        except Full:
+            pass
+        self.assertEqual(1, q.qsize())
+
+        # Pause to allow queue to complete operation before terminating
+        # Otherwise sometimes results in 'IOError: [Errno 32] Broken pipe'
+        time.sleep(0.1)

--- a/test/test_methods.py
+++ b/test/test_methods.py
@@ -23,11 +23,11 @@ from __future__ import division
 import StringIO
 import operator
 import os
+import Queue
 import random
 import time
 import warnings
 
-from Queue import Full, Empty
 
 # LEMON modules
 from test import unittest
@@ -376,24 +376,19 @@ class StreamToWarningFilterTest(unittest.TestCase):
 class MethodsQueueTest(unittest.TestCase):
 
     def test_queue_min_size(self):
-        q = methods.Queue(1)
+        q = methods.Queue()
         self.assertEqual(q.qsize(), 0)
-        try:
+        with self.assertRaises(Queue.Empty):
             q.get_nowait()
-        except Empty:
-            pass
         self.assertEqual(q.qsize(), 0)
 
     def test_queue_max_size(self):
-        q = methods.Queue(1)
-
+        q = methods.Queue(maxsize=1)
         self.assertEqual(0, q.qsize())
         q.put_nowait("1")
         self.assertEqual(1, q.qsize())
-        try:
+        with self.assertRaises(Queue.Full):
             q.put_nowait("1")
-        except Full:
-            pass
         self.assertEqual(1, q.qsize())
 
         # Pause to allow queue to complete operation before terminating


### PR DESCRIPTION
Reorders calls to Queue's superclass so exceptions thrown by no_wait/timeouts will not leave an incorrect size reported by qsize()