### PR TITLE
bugfix when doing photometry and some objects very very near zero ra dec

### DIFF
--- a/methods.py
+++ b/methods.py
@@ -284,7 +284,7 @@ def load_coordinates(path):
             if re.match(regexp, line):
                 continue
 
-            kwargs = dict(float = "([+-]?\d+(\.\d+)*)")
+            kwargs = dict(float = "([+-]?\d+(\.\d+)(?:[eE][+\-]?\d+)*)")
             regexp = ("^\s*"
                       "(?P<ra>{float})"
                       "\s+"

--- a/test/test_methods.py
+++ b/test/test_methods.py
@@ -158,19 +158,22 @@ class LoadCoordinatesTest(unittest.TestCase):
             coordinates = methods.load_coordinates(path)
             coords_list = list(coordinates)
             self.assertEqual(len(coords_list), 1)
-            self.assertEqual(coords_list[0], (7.9720694373e-05, 44.6352243008, None, None))
+            ra, dec, pm_ra, pm_dec = coords_list[0]
+            self.assertAlmostEqual(ra, 7.9720694373e-05)
+            self.assertAlmostEqual(dec, 44.6352243008)
 
     def test_load_coordinates_scientific_notation_with_propper_motion(self):
-
-        # For some datasets that generate coords so close to zero that they end up in scientific notation
 
         data = '7.9720694373e-05 44.6352243008 [0.00123] [0.0000432]'
         with methods.tempinput(data) as path:
             coordinates = methods.load_coordinates(path)
             coords_list = list(coordinates)
             self.assertEqual(len(coords_list), 1)
-            self.assertEqual(coords_list[0], (7.9720694373e-05, 44.6352243008, 0.00123, 4.32e-05))
-
+            ra, dec, pm_ra, pm_dec = coords_list[0]
+            self.assertAlmostEqual(ra, 7.9720694373e-05)
+            self.assertAlmostEqual(dec, 44.6352243008)
+            self.assertAlmostEqual(pm_ra, 0.00123)
+            self.assertAlmostEqual(pm_dec, 4.32e-05)
 
     def test_load_coordinates_empty_lines_and_comments(self):
 

--- a/test/test_methods.py
+++ b/test/test_methods.py
@@ -149,6 +149,18 @@ class LoadCoordinatesTest(unittest.TestCase):
                 for coords, expected in zip(coordinates, objects):
                     self.assertEqual(coords, expected)
 
+    def test_load_coordinates_sci_notation(self):
+
+        # For some datasets that generate coords so close to zero that they end up in scientific notation
+
+        for _ in xrange(NITERS):
+            data = '7.9720694373e-05 44.6352243008'
+            with methods.tempinput(data) as path:
+                coordinates = methods.load_coordinates(path)
+                for coords in coordinates:
+                    self.assertEqual(coords, (7.9720694373e-05, 44.6352243008, None, None))
+
+
     def test_load_coordinates_empty_lines_and_comments(self):
 
         # The same as test_load_coordinates(), but randomly inserting a few

--- a/test/test_methods.py
+++ b/test/test_methods.py
@@ -149,16 +149,27 @@ class LoadCoordinatesTest(unittest.TestCase):
                 for coords, expected in zip(coordinates, objects):
                     self.assertEqual(coords, expected)
 
-    def test_load_coordinates_sci_notation(self):
+    def test_load_coordinates_scientific_notation(self):
 
         # For some datasets that generate coords so close to zero that they end up in scientific notation
 
-        for _ in xrange(NITERS):
-            data = '7.9720694373e-05 44.6352243008'
-            with methods.tempinput(data) as path:
-                coordinates = methods.load_coordinates(path)
-                for coords in coordinates:
-                    self.assertEqual(coords, (7.9720694373e-05, 44.6352243008, None, None))
+        data = '7.9720694373e-05 44.6352243008'
+        with methods.tempinput(data) as path:
+            coordinates = methods.load_coordinates(path)
+            coords_list = list(coordinates)
+            self.assertEqual(len(coords_list), 1)
+            self.assertEqual(coords_list[0], (7.9720694373e-05, 44.6352243008, None, None))
+
+    def test_load_coordinates_scientific_notation_with_propper_motion(self):
+
+        # For some datasets that generate coords so close to zero that they end up in scientific notation
+
+        data = '7.9720694373e-05 44.6352243008 [0.00123] [0.0000432]'
+        with methods.tempinput(data) as path:
+            coordinates = methods.load_coordinates(path)
+            coords_list = list(coordinates)
+            self.assertEqual(len(coords_list), 1)
+            self.assertEqual(coords_list[0], (7.9720694373e-05, 44.6352243008, 0.00123, 4.32e-05))
 
 
     def test_load_coordinates_empty_lines_and_comments(self):


### PR DESCRIPTION
Found this when running against my HAT-P-18b data  https://twitter.com/BallyhouraStars/status/1114895128286642176

Some of the RA coordinates were almost zero and were in the temp file in scientific notation. The regex just needed a small tweak. Test added to replicate problem before fix.