### PR TITLE
Bugfix: multiprocessing queue doesn't pickle _size

### DIFF
--- a/util/queue.py
+++ b/util/queue.py
@@ -66,7 +66,7 @@ class Queue(multiprocessing.queues.Queue):
     """
 
     def __init__(self, *args, **kwargs):
-        super(Queue, self).__init__(*args, **kwargs)
+        super(Queue, self).__init__(*args, **kwargs, ctx=multiprocessing.get_context())
         self._size = SharedCounter(0)
 
     def put(self, *args, **kwargs):

--- a/util/queue.py
+++ b/util/queue.py
@@ -69,6 +69,14 @@ class Queue(multiprocessing.queues.Queue):
         super(Queue, self).__init__(*args, **kwargs, ctx=multiprocessing.get_context())
         self._size = SharedCounter(0)
 
+    # __getstate__ and __setstate__ are needed for pickling, otherwise _size won't be copied.
+    def __getstate__(self):
+        return super(Queue, self).__getstate__() + (self._size,)
+
+    def __setstate__(self, state):
+        self._size = state[-1]
+        super(Queue, self).__setstate__(state[:-1])
+
     def put(self, *args, **kwargs):
         super(Queue, self).put(*args, **kwargs)
         self._size.increment(1)


### PR DESCRIPTION
I needed to make these small changes in order to get queue working with my multiprocessing code. 

There were two issues:
1. `multiprocessing.queues.Queue.__init__` takes a `ctx` argument, which was not provided
1. if you are using spawn rather than fork with multiprocessing (e.g. running on Windows), `_size` doesn't get pickled, and get/put/etc will throw an AttributeError about there being no such attribute